### PR TITLE
fix: add profiles for dist-all.

### DIFF
--- a/dist/dist-all/pom.xml
+++ b/dist/dist-all/pom.xml
@@ -11,38 +11,70 @@
   <artifactId>all</artifactId>
   <packaging>jar</packaging>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.intel.analytics.bigdl.core.native.mkl</groupId>
-      <artifactId>mkl-java-x86_64-linux</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.intel.analytics.bigdl.core.native.bigquant</groupId>
-      <artifactId>bigquant-java-x86_64-linux</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.intel.analytics.bigdl.core.native.mkl</groupId>
-      <artifactId>mkl-java-mac</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.intel.analytics.bigdl.core.native.bigquant</groupId>
-      <artifactId>bigquant-java-mac</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.intel.analytics.bigdl.core.native.mkl</groupId>
-      <artifactId>mkl-java-win64</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.intel.analytics.bigdl.core.native.bigquant</groupId>
-      <artifactId>bigquant-java-win64</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-  </dependencies>
+  <profiles>
+    <profile>
+      <id>linux</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.intel.analytics.bigdl.core.dist</groupId>
+          <artifactId>linux</artifactId>
+          <version>${project.version}</version>
+          <type>pom</type>
+        </dependency>
+      </dependencies>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>win64</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.intel.analytics.bigdl.core.dist</groupId>
+          <artifactId>win64</artifactId>
+          <version>${project.version}</version>
+          <type>pom</type>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>mac</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.intel.analytics.bigdl.core.dist</groupId>
+          <artifactId>mac</artifactId>
+          <version>${project.version}</version>
+          <type>pom</type>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>deploy</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.intel.analytics.bigdl.core.dist</groupId>
+          <artifactId>linux</artifactId>
+          <version>${project.version}</version>
+          <type>pom</type>
+        </dependency>
+        <dependency>
+          <groupId>com.intel.analytics.bigdl.core.dist</groupId>
+          <artifactId>win64</artifactId>
+          <version>${project.version}</version>
+          <type>pom</type>
+        </dependency>
+        <dependency>
+          <groupId>com.intel.analytics.bigdl.core.dist</groupId>
+          <artifactId>mac</artifactId>
+          <version>${project.version}</version>
+          <type>pom</type>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>


### PR DESCRIPTION
Because dist-all will contain all platforms libraries, it will conflict
with the same classes, MKL.class, Loader.class and BigQuant.class.

For maven, it will pass by default. But for sbt, it will need
mergeStragy to handle the conflicts. So we make the packaging as a
jar.

After it becomes a jar, the default `mvn clean package` will package it
on all platforms. We need an ugly command on each platform:

`mvn clean package -P linux -pl '!dist/dist-all'`

So add the profiles to handle this. `mvn clean package -P linux`
will generate a `all-0.4.0-SNAPSHOT.jar` which only contains the linux
libraries.

`mvn clean package -P deploy` will generate a jar which contains all
libraries. But you should copy all pre-built libraries to
`target/classes` folder at first.