### PR TITLE
fix: rh5 of opencv

### DIFF
--- a/dist/dist-all/pom.xml
+++ b/dist/dist-all/pom.xml
@@ -52,6 +52,10 @@
     </profile>
 
     <profile>
+      <id>rh5</id>
+    </profile>
+
+    <profile>
       <id>deploy</id>
       <dependencies>
         <dependency>

--- a/opencv/pom.xml
+++ b/opencv/pom.xml
@@ -41,6 +41,10 @@
         </profile>
 
         <profile>
+            <id>rh5</id>
+        </profile>
+
+        <profile>
             <id>deploy</id>
             <modules>
                 <module>opencv-java-x86_64-linux</module>


### PR DESCRIPTION
By default, it will run test of opencv on redhat5, which is not supported currently.