### PR TITLE
fix: opencv package error. Because we delete the opencv-320.jar under…

### DIFF
--- a/dist/dist-all/pom.xml
+++ b/dist/dist-all/pom.xml
@@ -96,6 +96,12 @@
                 <include>**</include>
               </includes>
             </filter>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>opencv-320.jar</exclude>
+              </excludes>
+            </filter>
           </filters>
         </configuration>
         <executions>

--- a/opencv/opencv-java-win64/pom.xml
+++ b/opencv/opencv-java-win64/pom.xml
@@ -64,19 +64,6 @@
                             <goal>run</goal>
                         </goals>
                     </execution>
-                    <execution>
-                        <id>prepare-package</id>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <tasks>
-                                <echo>Delete opencv-320.jar.</echo>
-                                <delete file="${project.build.directory}/classes/${opencvjar}"/>
-                            </tasks>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
… the classes in opencv-java-win64