### PR TITLE
feat: int8 supports, add some missing api

### DIFF
--- a/native-dnn/src/main/c/common.c
+++ b/native-dnn/src/main/c/common.c
@@ -304,8 +304,8 @@ JNIEXPORT void JNICALL PREFIX(AttrSetOutputScales)(JNIEnv* env,
                                                    int count,
                                                    int mask,
                                                    jfloatArray scales) {
-  /* mkldnn will copy the j_scales to the internal buffer, so do not worry about
-   * the memory address moving by GC*/
+  /* mkldnn will copy the j_scales to the internal buffer, so no need to worry
+   * about the memory address moving by GC*/
   float* j_scales = (*env)->GetPrimitiveArrayCritical(env, scales, JNI_FALSE);
 
   CHECK_EXCEPTION(env,

--- a/native-dnn/src/main/c/engine.c
+++ b/native-dnn/src/main/c/engine.c
@@ -21,6 +21,17 @@ JNIEXPORT void PREFIX(Destroy)(JNIEnv *env, jclass cls, long engine) {
   CHECK(mkldnn_engine_destroy((mkldnn_engine_t)engine));
 }
 
+JNIEXPORT long PREFIX(Query)(JNIEnv *env, jclass cls, long primitive_desc) {
+  mkldnn_engine_t engine;
+
+  CHECK(mkldnn_primitive_desc_query((mkldnn_primitive_desc_t) primitive_desc,
+                                    mkldnn_query_engine,
+                                    0,
+                                    &engine));
+
+  return (long) engine;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/native-dnn/src/main/c/memory.c
+++ b/native-dnn/src/main/c/memory.c
@@ -21,12 +21,12 @@ JNIEXPORT long JNICALL Java_com_intel_analytics_bigdl_mkl_MklDnn_MemoryDescInit(
                                                     JNI_FALSE);
 
   mkldnn_memory_desc_t *desc = malloc(sizeof(mkldnn_memory_desc_t));
-  mkldnn_status_t ret = mkldnn_memory_desc_init(desc,
-                            ndims,
-                            j_dims,
-                            (mkldnn_data_type_t)data_type,
-                            (mkldnn_memory_format_t)format);
-  CHECK(ret);
+  CHECK_EXCEPTION(env,
+                  mkldnn_memory_desc_init(desc,
+                                          ndims,
+                                          j_dims,
+                                          (mkldnn_data_type_t)data_type,
+                                          (mkldnn_memory_format_t)format));
 
   (*env)->ReleasePrimitiveArrayCritical(env, dims, j_dims, 0);
 

--- a/native-dnn/src/main/c/memory2.c
+++ b/native-dnn/src/main/c/memory2.c
@@ -8,22 +8,42 @@
 
 #define PREFIX(func) Java_com_intel_analytics_bigdl_mkl_Memory_##func
 
-static void fast_copy(float *dst, float *src, const size_t n) {
+static void fast_copy(float *dst, float *src, const size_t n,
+                      const size_t element_size) {
   int threshold = omp_get_max_threads();
   const int run_parallel = (n >= threshold) && (omp_in_parallel() == 0);
 
   if (run_parallel) {
     const int block_mem_size = 256 * 1024;
-    const int block_size = block_mem_size / sizeof(float);
+    const int block_size = block_mem_size / element_size;
 #pragma omp parallel for
     for (size_t i = 0; i < n; i += block_size)
       memcpy(dst + i, src + i,
-             (i + block_size > n) ? (n - i) * sizeof(float) : block_mem_size);
+             (i + block_size > n) ? (n - i) * element_size : block_mem_size);
 
     return;
   }
 
-  memcpy(dst, src, sizeof(float) * n);
+  memcpy(dst, src, element_size * n);
+}
+
+static void fast_copy_byte(char *dst, char *src, const size_t n,
+                           const size_t element_size) {
+  int threshold = omp_get_max_threads();
+  const int run_parallel = (n >= threshold) && (omp_in_parallel() == 0);
+
+  if (run_parallel) {
+    const int block_mem_size = 256 * 1024;
+    const int block_size = block_mem_size / element_size;
+#pragma omp parallel for
+    for (size_t i = 0; i < n; i += block_size)
+      memcpy(dst + i, src + i,
+             (i + block_size > n) ? (n - i) * element_size : block_mem_size);
+
+    return;
+  }
+
+  memcpy(dst, src, element_size * n);
 }
 
 #ifdef __cplusplus
@@ -50,7 +70,7 @@ JNIEXPORT jlong JNICALL PREFIX(CopyPtr2Ptr)(JNIEnv *env, jclass cls, jlong src,
                                             jint srcOffset, jlong dst,
                                             jint dstOffset, jint length,
                                             jint element_size) {
-  fast_copy((float *)dst + dstOffset, (float *)src + srcOffset, length);
+  fast_copy((float *)dst + dstOffset, (float *)src + srcOffset, length, element_size);
   return 0;
 }
 
@@ -60,7 +80,7 @@ JNIEXPORT jlong JNICALL PREFIX(CopyArray2Ptr)(JNIEnv *env, jclass cls,
                                               jint length, jint element_size) {
   float *j_src = (*env)->GetPrimitiveArrayCritical(env, src, JNI_FALSE);
   float *j_dst = (float *)dst;
-  fast_copy(j_dst + dstOffset, j_src + srcOffset, length);
+  fast_copy(j_dst + dstOffset, j_src + srcOffset, length, element_size);
   (*env)->ReleasePrimitiveArrayCritical(env, src, j_src, 0);
   return 0;
 }
@@ -70,7 +90,7 @@ JNIEXPORT jlong JNICALL PREFIX(CopyPtr2Array)(JNIEnv *env, jclass cls,
                                               jfloatArray dst, jint dstOffset,
                                               jint length, jint element_size) {
   float *j_dst = (*env)->GetPrimitiveArrayCritical(env, dst, JNI_FALSE);
-  fast_copy(j_dst + dstOffset, (float *)src + srcOffset, length);
+  fast_copy(j_dst + dstOffset, (float *)src + srcOffset, length, element_size);
   (*env)->ReleasePrimitiveArrayCritical(env, dst, j_dst, 0);
   return 0;
 }
@@ -120,16 +140,17 @@ JNIEXPORT void JNICALL PREFIX(Set)(JNIEnv *env, jclass cls, jlong ptr,
   }
 }
 
-JNIEXPORT jintArray JNICALL PREFIX(GetShape)
-  (JNIEnv *env, jclass cls, jlong desc) {
-    mkldnn_memory_desc_t *jni_desc = (mkldnn_memory_desc_t*)desc;
-    int *dims = jni_desc->dims;
-    int ndims = jni_desc->ndims;
+JNIEXPORT jintArray JNICALL PREFIX(GetShape)(JNIEnv* env,
+                                             jclass cls,
+                                             jlong desc) {
+  mkldnn_memory_desc_t* jni_desc = (mkldnn_memory_desc_t*)desc;
+  int ndims = jni_desc->ndims;
+  int* dims = jni_desc->dims;
 
-    jintArray result = (*env)->NewIntArray(env, ndims);
-    (*env)->SetIntArrayRegion(env, result, 0, ndims, dims);
-    return result;
-  }
+  jintArray result = (*env)->NewIntArray(env, ndims);
+  (*env)->SetIntArrayRegion(env, result, 0, ndims, dims);
+  return result;
+}
 
 JNIEXPORT jintArray JNICALL PREFIX(GetPaddingShape)(JNIEnv* env,
                                                     jclass cls,
@@ -145,11 +166,31 @@ JNIEXPORT jintArray JNICALL PREFIX(GetPaddingShape)(JNIEnv* env,
   return result;
 }
 
-JNIEXPORT jint JNICALL PREFIX(GetLayout)
-  (JNIEnv *env, jclass cls, jlong desc) {
-    mkldnn_memory_desc_t *jni_desc = (mkldnn_memory_desc_t*)desc;
-    return (int)(jni_desc->format);
-  }
+JNIEXPORT jint JNICALL PREFIX(GetLayout)(JNIEnv* env, jclass cls, jlong desc) {
+  mkldnn_memory_desc_t* jni_desc = (mkldnn_memory_desc_t*)desc;
+  return (int)(jni_desc->format);
+}
+
+JNIEXPORT jint JNICALL PREFIX(GetDataType)(JNIEnv* env,
+                                           jclass cls,
+                                           jlong desc) {
+  mkldnn_memory_desc_t* jni_desc = (mkldnn_memory_desc_t*)desc;
+  return (int)(jni_desc->data_type);
+}
+
+JNIEXPORT jlong JNICALL PREFIX(CopyPtr2ByteArray)(JNIEnv* env,
+                                                  jclass cls,
+                                                  jlong src,
+                                                  jint srcOffset,
+                                                  jbyteArray dst,
+                                                  jint dstOffset,
+                                                  jint length,
+                                                  jint element_size) {
+  char* j_dst = (*env)->GetPrimitiveArrayCritical(env, dst, JNI_FALSE);
+  fast_copy_byte(j_dst + dstOffset, (char*)src + srcOffset, length, 1);
+  (*env)->ReleasePrimitiveArrayCritical(env, dst, j_dst, 0);
+  return 0;
+}
 
 #ifdef __cplusplus
 }

--- a/native-dnn/src/main/c/stream.c
+++ b/native-dnn/src/main/c/stream.c
@@ -23,18 +23,14 @@ JNIEXPORT void JNICALL PREFIX(Submit)(JNIEnv *env, jclass cls, long stream,
   jlong *j_primitives =
       (*env)->GetPrimitiveArrayCritical(env, primitives, JNI_FALSE);
 
-  // clock_t begin = clock();
   mkldnn_primitive_t prim[length];
   for (int i = 0; i < length; i++) {
     prim[i] = (mkldnn_primitive_t)(j_primitives[i]);
   }
-  CHECK(mkldnn_stream_submit((mkldnn_stream_t)stream, length, prim,
-                             NULL));  // TODO here should not be NULL
-  // clock_t end = clock();
-  // double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
-  // printf("time costs: %lf\n", time_spent);
-  // fflush(stdout);
 
+  CHECK_EXCEPTION(env,
+                  mkldnn_stream_submit((mkldnn_stream_t)stream, length, prim,
+                                       NULL));  // TODO here should not be NULL
   (*env)->ReleasePrimitiveArrayCritical(env, primitives, j_primitives, 0);
 }
 

--- a/native-dnn/src/main/c/utils.c
+++ b/native-dnn/src/main/c/utils.c
@@ -1,0 +1,84 @@
+#include <execinfo.h> /* for the backtrace api */
+#include <jni.h>      /* for the JNIEnv */
+#include <stdlib.h>
+
+#include "mkldnn_types.h" /* for status of return value of mkldnn */
+
+static jint throwException(JNIEnv* env, const char* message) {
+  char* className = "java/lang/Exception";
+
+  jclass exClass = (*env)->FindClass(env, className);
+  return (*env)->ThrowNew(env, exClass, message);
+}
+
+static jint throwIllegalArgumentException(JNIEnv* env, const char* message) {
+  char* className = "java/lang/IllegalArgumentException";
+
+  jclass exClass = (*env)->FindClass(env, className);
+  return (*env)->ThrowNew(env, exClass, message);
+}
+
+static jint throwOutOfMemoryError(JNIEnv* env, const char* message) {
+  char* className = "java/lang/OutOfMemoryError";
+
+  jclass exClass = (*env)->FindClass(env, className);
+  return (*env)->ThrowNew(env, exClass, message);
+}
+
+static int throwUnsupportedaOperationException(JNIEnv* env,
+                                               const char* message) {
+  char* className = "java/lang/UnsupportedOperationException";
+
+  jclass exClass = (*env)->FindClass(env, className);
+  return (*env)->ThrowNew(env, exClass, message);
+}
+
+static int throwUnimplementedException(JNIEnv* env, const char* message) {
+  char* className = "java/lang/UnimplementedException";
+
+  jclass exClass = (*env)->FindClass(env, className);
+  return (*env)->ThrowNew(env, exClass, message);
+}
+
+void throw_exception_if_failed(JNIEnv* env,
+                               mkldnn_status_t status,
+                               const char* file_name,
+                               const char* func_name,
+                               int line_num) {
+  if (status == mkldnn_success) {
+    return; /* right, do nothing */
+  }
+
+  const static int BT_BUF_SIZE = 100; /* buffer size for trace entries */
+
+  void* addresses[BT_BUF_SIZE];
+  size_t actual_entries = backtrace(addresses, BT_BUF_SIZE);
+  fprintf(stderr, "Obtained %zd stack frames.\n", actual_entries);
+
+  char** printable_representation =
+      backtrace_symbols(addresses, actual_entries);
+  for (int j = 0; j < actual_entries; j++) {
+    fprintf(stderr, "[FRAME %d] %s\n", j, printable_representation[j]);
+  }
+  fprintf(stderr, "\n[%s:%d] error: %s returns %d\n", file_name, line_num,
+          func_name, status);
+  free(printable_representation); /* never forget to free the memory */
+
+  switch (status) {
+    case mkldnn_invalid_arguments:
+      throwIllegalArgumentException(env, "[mkldnn] ivalid arguments");
+      break;
+
+    case mkldnn_out_of_memory:
+      throwOutOfMemoryError(env, "[mkldnn] out of memory");
+      break;
+
+    case mkldnn_unimplemented:
+      throwUnimplementedException(env, "[mkldnn] unimplemented");
+      break;
+
+    default:
+      throwException(env, "[mkldnn] unknown type error");
+      break;
+  }
+}

--- a/native-dnn/src/main/c/utils.h
+++ b/native-dnn/src/main/c/utils.h
@@ -1,40 +1,63 @@
+#ifndef _UTILS_H
+#define _UTILS_H
+
 #include <execinfo.h>
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "mkldnn.h"
 
-#define BT_BUF_SIZE 100
+#ifdef __cplusplus
+extern "C" {
+#endif
+/* we should export `throw_exception_if_failed` for macro CHECK_EXCEPTION */
+void throw_exception_if_failed(JNIEnv* env,
+                               mkldnn_status_t status,
+                               const char* file_name,
+                               const char* func_name,
+                               int line_num);
+#ifdef __cplusplus
+}
+#endif
 
-#define CHECK(f)                                                               \
-  do {                                                                       \
+/* TODO replace this three macros to CHECK_EXCEPTION */
+#define BT_BUF_SIZE 100
+#define CHECK(f)                                                           \
+  do {                                                                     \
     mkldnn_status_t s = f;                                                 \
     if (s != mkldnn_success) {                                             \
-      int j, nptrs; \
-      void *buffer[BT_BUF_SIZE]; \
-      char **strings; \
-      nptrs = backtrace(buffer, BT_BUF_SIZE); \
-      printf("backtrace() returned %d addresses\n", nptrs); \
-      strings = backtrace_symbols(buffer, nptrs); \
-      if (strings == NULL) { \
-        perror("backtrace_symbols"); \
-        exit(EXIT_FAILURE); \
-      } \
-      for (j = 0; j < nptrs; j++) \
-      printf("%s\n", strings[j]); \
-      free(strings); \
-      printf("[%s:%d] error: %s returns %d\n", __FILE__, __LINE__, #f,   \
-             s);                                                         \
-      exit(2);                                                           \
+      int j, nptrs;                                                        \
+      void* buffer[BT_BUF_SIZE];                                           \
+      char** strings;                                                      \
+      nptrs = backtrace(buffer, BT_BUF_SIZE);                              \
+      printf("backtrace() returned %d addresses\n", nptrs);                \
+      strings = backtrace_symbols(buffer, nptrs);                          \
+      if (strings == NULL) {                                               \
+        perror("backtrace_symbols");                                       \
+        exit(EXIT_FAILURE);                                                \
+      }                                                                    \
+      for (j = 0; j < nptrs; j++)                                          \
+        printf("%s\n", strings[j]);                                        \
+      free(strings);                                                       \
+      printf("[%s:%d] error: %s returns %d\n", __FILE__, __LINE__, #f, s); \
+      exit(2);                                                             \
     }                                                                      \
   } while (0)
 
-#define CHECK_TRUE(expr)                                                       \
-    do {                                                                       \
-        int e_ = expr;                                                         \
-        if (!e_) {                                                             \
-            printf("[%s:%d] %s failed\n", __FILE__, __LINE__, #expr);          \
-            exit(2);                                                           \
-        }                                                                      \
-    } while (0)
+#define CHECK_TRUE(expr)                                        \
+  do {                                                          \
+    int e_ = expr;                                              \
+    if (!e_) {                                                  \
+      printf("[%s:%d] %s failed\n", __FILE__, __LINE__, #expr); \
+      exit(2);                                                  \
+    }                                                           \
+  } while (0)
 
+#define CHECK_EXCEPTION(env, f)                                           \
+  do {                                                                    \
+    mkldnn_status_t status = f;                                           \
+    throw_exception_if_failed(env, status, __FILE__, __PRETTY_FUNCTION__, \
+                              __LINE__);                                  \
+  } while (0)
 
+#endif

--- a/native-dnn/src/main/java/com/intel/analytics/bigdl/mkl/Engine.java
+++ b/native-dnn/src/main/java/com/intel/analytics/bigdl/mkl/Engine.java
@@ -24,4 +24,5 @@ public class Engine {
 
     public native static long Create(int id, int index);
     public native static void Destroy(long engine);
+    public native static long Query(long primitiveDescriptor);
 }

--- a/native-dnn/src/main/java/com/intel/analytics/bigdl/mkl/Memory.java
+++ b/native-dnn/src/main/java/com/intel/analytics/bigdl/mkl/Memory.java
@@ -146,6 +146,9 @@ public class Memory {
                                             int length, int elementSize);
     public native static long CopyPtr2Array(long src, int srcOffset, float[] dst, int dstOffset,
                                             int length, int elementSize);
+
+    public native static long CopyPtr2ByteArray(long src, int srcOffset, byte[] dst, int dstOffset,
+                                                int length, int elementSize);
     public native static long AlignedMalloc(int capacity, int size);
     public native static void AlignedFree(long ptr);
 
@@ -159,4 +162,6 @@ public class Memory {
     public native static int[] GetShape(long desc);
     public native static int[] GetPaddingShape(long desc);
     public native static int GetLayout(long desc);
+    public native static int GetDataType(long desc);
+    public native static long GetSize(long desc);
 }

--- a/native-dnn/src/main/java/com/intel/analytics/bigdl/mkl/MklDnn.java
+++ b/native-dnn/src/main/java/com/intel/analytics/bigdl/mkl/MklDnn.java
@@ -137,6 +137,7 @@ public class MklDnn {
                                                       int[] padding_r, int padding_kind);
 
     public native static long ReorderPrimitiveDescCreate(long input, long output);
+    public native static long ReorderPrimitiveDescCreateV2(long input, long output, long attr);
 
     public native static int MemoryPrimitiveDescEqual(long lhs, long rhs);
 
@@ -237,4 +238,6 @@ public class MklDnn {
     // attr
     public native static long CreateAttr();
     public native static void DestroyAttr(long attr);
+    public native static void AttrSetIntOutputRoundMode(long attr, int roundMode);
+    public native static void AttrSetOutputScales(long attr, int count, int mask, float[] scales);
 }


### PR DESCRIPTION
First, this patch add some int8 relavant APIs, such as copying byte buffer,
settings output scales and settings round mode and so on. Second, this patch
refactor the exception handling and error message showing. The error message
will be more clear.
