### PR TITLE
fix: affinity will not work on cgroup envs, such as in docker

### DIFF
--- a/native-dnn/src/main/c/affinity.c
+++ b/native-dnn/src/main/c/affinity.c
@@ -63,16 +63,24 @@ JNIEXPORT jint JNICALL
   return ret;
 }
 
-JNIEXPORT void JNICALL PREFIX(setOmpAffinity0)(JNIEnv *env, jclass class, jint size)
+JNIEXPORT void JNICALL PREFIX(setOmpAffinity0)(JNIEnv *env, jclass class, jintArray set)
 {
+  int available_cores_num = (*env)->GetArrayLength(env, set);
+  int *available_cores = (*env)->GetPrimitiveArrayCritical(env, set, JNI_FALSE);
+
 #pragma omp parallel
   {
     int id = omp_get_thread_num();
+    int core_id = available_cores[ id % available_cores_num ];
+
     cpu_set_t mask;
     CPU_ZERO(&mask);
-    CPU_SET(id, &mask);
+    CPU_SET(core_id, &mask);
+
     sched_setaffinity(0, sizeof(mask), &mask);
   }
+
+  (*env)->ReleasePrimitiveArrayCritical(env, set, available_cores, 0);
 }
 #ifdef __cplusplus
 }

--- a/native-dnn/src/main/java/com/intel/analytics/bigdl/mkl/hardware/platform/linux/LinuxAffinity.java
+++ b/native-dnn/src/main/java/com/intel/analytics/bigdl/mkl/hardware/platform/linux/LinuxAffinity.java
@@ -8,7 +8,7 @@ import java.util.BitSet;
 public class LinuxAffinity implements IAAffinity {
     public static native int setAffinity0(int[] sets);
     public static native int getAffinity0(int[] sets, int cpuCounts);
-    public static native void setOmpAffinity0(int size);
+    public static native void setOmpAffinity0(int[] sets);
 
     private int cpuCounts;
     private boolean[] availableCPUs;
@@ -45,7 +45,7 @@ public class LinuxAffinity implements IAAffinity {
     }
 
     public synchronized void setOmpAffinity() {
-        setOmpAffinity0(cpuCounts / 2);
+        setOmpAffinity0(getAffinity());
     }
 
     public synchronized int[] getAffinity() {

--- a/native-dnn/src/test/java/com/intel/analytics/bigdl/mkl/AffinityTest.java
+++ b/native-dnn/src/test/java/com/intel/analytics/bigdl/mkl/AffinityTest.java
@@ -8,16 +8,21 @@ import static org.junit.Assert.assertTrue;
 public class AffinityTest {
     @Test
     public void SetSingleAffinity() {
+        int[] backup = Affinity.getAffinity();
+
         Affinity.setAffinity(3);
 
         int[] cores = Affinity.getAffinity();
 
         assertTrue(cores.length == 1);
         assertTrue(cores[0] == 3);
+
+        Affinity.setAffinity(backup);
     }
 
     @Test
     public void SetMultiAffinity() {
+        int[] backup = Affinity.getAffinity();
         int[] cores = {1, 2, 3};
         Affinity.setAffinity(cores);
 
@@ -27,16 +32,21 @@ public class AffinityTest {
         assertTrue(getCores[0] == 1);
         assertTrue(getCores[1] == 2);
         assertTrue(getCores[2] == 3);
+
+        Affinity.setAffinity(backup);
     }
 
     @Test
     public void SetOmpAffinity() {
+        int[] backup = Affinity.getAffinity();
         Affinity.setOmpAffinity();
 
         int[] cores = Affinity.getAffinity();
 
         assertTrue(cores.length == 1);
         assertTrue(cores[0] == 0);
+
+        Affinity.setAffinity(backup);
     }
 
 }


### PR DESCRIPTION
In a cgroup envs, the processes or threads inherit the affinity setting. So when do affinity binding, we should take care how many cores we can use and what're them.