### PR TITLE
Make java.library.path warning configurable

### DIFF
--- a/mkl2017-xeon-blas/src/main/java/com/intel/analytics/bigdl/mkl/MKL.java
+++ b/mkl2017-xeon-blas/src/main/java/com/intel/analytics/bigdl/mkl/MKL.java
@@ -377,7 +377,7 @@ public class MKL {
     }
 
     private static boolean tryLoadLibrary(String[] libs) {
-        System.out.println("try loading native libraries from java.library.path");
+        log("try loading native libraries from java.library.path");
         try {
             for (int i = 0; i < libs.length; i++) {
                 String libName = libs[i];
@@ -391,7 +391,7 @@ public class MKL {
             log("[DEBUG] Loaded native libraries from java.library.path");
             return true;
         } catch (UnsatisfiedLinkError e) {
-            System.out.println("tryLoadLibraryFailed: " + e.getMessage());
+            log("ryLoadLibraryFailed: " + e.getMessage());
             return false;
         }
 

--- a/mkl2017-xeon-blas/src/main/java/com/intel/analytics/bigdl/mkl/MKL.java
+++ b/mkl2017-xeon-blas/src/main/java/com/intel/analytics/bigdl/mkl/MKL.java
@@ -391,7 +391,7 @@ public class MKL {
             log("[DEBUG] Loaded native libraries from java.library.path");
             return true;
         } catch (UnsatisfiedLinkError e) {
-            log("ryLoadLibraryFailed: " + e.getMessage());
+            log("tryLoadLibraryFailed: " + e.getMessage());
             return false;
         }
 

--- a/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
+++ b/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
@@ -43,7 +43,7 @@ public class OpenCV {
         String jopencvFileName = "libopencv_java320.so";
         // Load from LD_PATH
         try {
-                System.out.println("try loading opencv_java320 from java.library.path ");
+                log("try loading opencv_java320 from java.library.path ");
                 String libName = jopencvFileName;
                 if (libName.indexOf(".") != -1) {
                     // Remove lib and .so
@@ -53,7 +53,7 @@ public class OpenCV {
                 isLoaded = true;
                 log("[DEBUG] loaded " + libName + " from java.library.path");
         } catch (UnsatisfiedLinkError e) {
-            System.out.println("tryLoadLibraryFailed: " + e.getMessage());
+            log("tryLoadLibraryFailed: " + e.getMessage());
         }
         if (!isLoaded) {
             try {


### PR DESCRIPTION
* Make java.library.path warning configurable. Disable by default. Can be enabled by `-Dcom.intel.analytics.bigdl.mkl.MKL.DEBUG` and `-Dom.intel.analytics.bigdl.opencv.OpenCV.DEBUG`.