### PR TITLE
Support Opencv4.2(load opencv dependency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ XCode 9.0
 
 ## Building from Source
 
-### Prepare OpenCV 3.2.0
+### Prepare OpenCV 4.2.0
 
-Download `opencv-320.jar` from maven. Copy this jar to `/opt/opencv` dir. Extract `libopencv_java320.so` (Linux) or `libopencv_java320.dylib` (macOS) from `opencv-320.jar`, and move to `/opt/opencv`.
+Download `opencv-420.jar` from maven. Copy this jar to `/opt/opencv` dir. Extract `libopencv_java420.so` (Linux) or `libopencv_java420.dylib` (macOS) from `opencv-420.jar`, and move to `/opt/opencv`.
 
 Or you can build this 2 files from OpenCV source code.
 
@@ -51,9 +51,9 @@ cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -DBUILD_TES
 make && make install
 # Copy jar & libs to /opt/opencv
 mkdir /opt/opencv
-scp ./bin/opencv-420.jar /opt/opencv
+cp ./bin/opencv-420.jar /opt/opencv
 # Change to libopencv_java420.dylib in MacOS
-scp ./lib/libopencv_java420.so /opt/opencv
+cp ./lib/libopencv_java420.so /opt/opencv
 cd ../.. && rm -rf 4.2.0.tar.gz
 ```
 

--- a/opencv/opencv-java-mac/pom.xml
+++ b/opencv/opencv-java-mac/pom.xml
@@ -16,7 +16,10 @@
 
     <properties>
         <opencvlib>libopencv_java420.dylib</opencvlib>
-        <libpng>libpng16.16.dylib</libpng>
+        <libopencv_core>libopencv_core.4.2.0.dylib</libopencv_core>
+        <libopencv_imgcodecs>libopencv_imgcodecs.4.2.0.dylib</libopencv_imgcodecs>
+        <libopencv_imgproc>libopencv_imgproc.4.2.0.dylib</libopencv_imgproc>
+        <libopencv_java>libopencv_java420.dylib</libopencv_java>
         <opencvjar>opencv-420.jar</opencvjar>
         <opencvDir>/opt/opencv/</opencvDir>
     </properties>

--- a/opencv/opencv-java-mac/pom.xml
+++ b/opencv/opencv-java-mac/pom.xml
@@ -19,7 +19,6 @@
         <libopencv_core>libopencv_core.4.2.0.dylib</libopencv_core>
         <libopencv_imgcodecs>libopencv_imgcodecs.4.2.0.dylib</libopencv_imgcodecs>
         <libopencv_imgproc>libopencv_imgproc.4.2.0.dylib</libopencv_imgproc>
-        <libopencv_java>libopencv_java420.dylib</libopencv_java>
         <opencvjar>opencv-420.jar</opencvjar>
         <opencvDir>/opt/opencv/</opencvDir>
     </properties>
@@ -30,7 +29,9 @@
                 <directory>${opencvDir}</directory>
                 <includes>
                     <include>${opencvlib}</include>
-                    <include>${libpng}</include>
+                    <include>${libopencv_core}</include>
+                    <include>${libopencv_imgcodecs}</include>
+                    <include>${libopencv_imgproc}</include>
                 </includes>
                 <targetPath>${project.build.directory}/classes</targetPath>
             </resource>

--- a/opencv/opencv-java-mac/pom.xml
+++ b/opencv/opencv-java-mac/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <opencvlib>libopencv_java420.dylib</opencvlib>
+        <libpng>libpng16.16.dylib</libpng>
         <opencvjar>opencv-420.jar</opencvjar>
         <opencvDir>/opt/opencv/</opencvDir>
     </properties>
@@ -26,6 +27,7 @@
                 <directory>${opencvDir}</directory>
                 <includes>
                     <include>${opencvlib}</include>
+                    <include>${libpng}</include>
                 </includes>
                 <targetPath>${project.build.directory}/classes</targetPath>
             </resource>

--- a/opencv/opencv-java-x86_64-linux/pom.xml
+++ b/opencv/opencv-java-x86_64-linux/pom.xml
@@ -16,7 +16,6 @@
 
     <properties>
         <opencvlib>libopencv_java420.so</opencvlib>
-        <libc>libdc1394.so.22</libc>
         <opencvjar>opencv-420.jar</opencvjar>
         <opencvDir>/opt/opencv/</opencvDir>
     </properties>
@@ -27,7 +26,6 @@
                 <directory>${opencvDir}</directory>
                 <includes>
                     <include>${opencvlib}</include>
-                    <include>${libc}</include>
                 </includes>
                 <targetPath>${project.build.directory}/classes</targetPath>
             </resource>

--- a/opencv/opencv-java-x86_64-linux/pom.xml
+++ b/opencv/opencv-java-x86_64-linux/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <opencvlib>libopencv_java420.so</opencvlib>
-        <libc>libdc1394.so.2</libc>
+        <libc>libdc1394.so.22</libc>
         <opencvjar>opencv-420.jar</opencvjar>
         <opencvDir>/opt/opencv/</opencvDir>
     </properties>

--- a/opencv/opencv-java-x86_64-linux/pom.xml
+++ b/opencv/opencv-java-x86_64-linux/pom.xml
@@ -16,6 +16,9 @@
 
     <properties>
         <opencvlib>libopencv_java420.so</opencvlib>
+        <libopencv_core>libopencv_core.so.4.2.0</libopencv_core>
+        <libopencv_imgcodecs>libopencv_imgcodecs.so.4.2.0</libopencv_imgcodecs>
+        <libopencv_imgproc>libopencv_imgproc.so.4.2.0</libopencv_imgproc>
         <opencvjar>opencv-420.jar</opencvjar>
         <opencvDir>/opt/opencv/</opencvDir>
     </properties>
@@ -26,6 +29,9 @@
                 <directory>${opencvDir}</directory>
                 <includes>
                     <include>${opencvlib}</include>
+                    <include>${libopencv_core}</include>
+                    <include>${libopencv_imgcodecs}</include>
+                    <include>${libopencv_imgproc}</include>
                 </includes>
                 <targetPath>${project.build.directory}/classes</targetPath>
             </resource>

--- a/opencv/opencv-java-x86_64-linux/pom.xml
+++ b/opencv/opencv-java-x86_64-linux/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <opencvlib>libopencv_java420.so</opencvlib>
+        <libc>libdc1394.so.2</libc>
         <opencvjar>opencv-420.jar</opencvjar>
         <opencvDir>/opt/opencv/</opencvDir>
     </properties>
@@ -26,6 +27,7 @@
                 <directory>${opencvDir}</directory>
                 <includes>
                     <include>${opencvlib}</include>
+                    <include>${libc}</include>
                 </includes>
                 <targetPath>${project.build.directory}/classes</targetPath>
             </resource>

--- a/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
+++ b/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
@@ -42,7 +42,7 @@ public class OpenCV {
     static {
         String[] LIBS = new String[]{
                 "libopencv_java420.so",
-                "libdc1394.so.2"};
+                "libdc1394.so.22"};
         isLoaded = tryLoadLibrary(LIBS);
         // Load from LD_PATH
         if (!isLoaded) {

--- a/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
+++ b/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
@@ -41,7 +41,10 @@ public class OpenCV {
 
     static {
         String[] LIBS = new String[]{
-                "libopencv_java420.so"};
+                "libopencv_java420.so",
+                "libopencv_core.so.4.2.0",
+                "libopencv_imgcodecs.so.4.2.0",
+                "libopencv_imgproc.so.4.2.0"};
         isLoaded = tryLoadLibrary(LIBS);
         // Load from LD_PATH
         if (!isLoaded) {
@@ -51,8 +54,7 @@ public class OpenCV {
                             "libopencv_java420.dylib",
                             "libopencv_core.4.2.0.dylib",
                             "libopencv_imgcodecs.4.2.0.dylib", 
-                            "libopencv_imgproc.4.2.0.dylib",
-                            "libopencv_java420.dylib",
+                            "libopencv_imgproc.4.2.0.dylib"
                     };
                 }
                 // TODO for windows, we don't create mkl.native dir

--- a/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
+++ b/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
@@ -51,7 +51,7 @@ public class OpenCV {
                             "libopencv_java420.dylib",
                             "libopencv_core.4.2.0.dylib",
                             "libopencv_imgcodecs.4.2.0.dylib", 
-                            "libopencv_imgproc.4.2.0.dylib"
+                            "libopencv_imgproc.4.2.0.dylib",
                             "libopencv_java420.dylib",
                     };
                 }

--- a/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
+++ b/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
@@ -49,7 +49,11 @@ public class OpenCV {
                 if (System.getProperty("os.name").toLowerCase().contains("mac")) {
                     LIBS = new String[]{
                             "libopencv_java420.dylib",
-                            "libpng16.16.dylib"};
+                            "libopencv_core.4.2.0.dylib",
+                            "libopencv_imgcodecs.4.2.0.dylib", 
+                            "libopencv_imgproc.4.2.0.dylib"
+                            "libopencv_java420.dylib",
+                    };
                 }
                 // TODO for windows, we don't create mkl.native dir
                 Path tempDir = null;

--- a/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
+++ b/opencv/src/main/java/com/intel/analytics/bigdl/opencv/OpenCV.java
@@ -41,8 +41,7 @@ public class OpenCV {
 
     static {
         String[] LIBS = new String[]{
-                "libopencv_java420.so",
-                "libdc1394.so.22"};
+                "libopencv_java420.so"};
         isLoaded = tryLoadLibrary(LIBS);
         // Load from LD_PATH
         if (!isLoaded) {
@@ -50,7 +49,7 @@ public class OpenCV {
                 if (System.getProperty("os.name").toLowerCase().contains("mac")) {
                     LIBS = new String[]{
                             "libopencv_java420.dylib",
-                            "libmklml.dylib"};
+                            "libpng16.16.dylib"};
                 }
                 // TODO for windows, we don't create mkl.native dir
                 Path tempDir = null;
@@ -65,6 +64,7 @@ public class OpenCV {
                     log("[DEBUG] Loading " + libName);
                     if (OpenCV.class.getResource("/" + libName) != null) {
                         try {
+                            System.out.printf("#####", libName);
                             tmpFile = extract(tempDir, libName);
                             System.load(tmpFile.getAbsolutePath());
                         } catch (Exception e) {


### PR DESCRIPTION
Compile OpenCV4.2:
`cmake -D CMAKE_BUILD_TYPE=RELEASE -D INSTALL_PYTHON_EXAMPLES=OFF -D INSTALL_C_EXAMPLES=OFF -D BUILD_DOCS=OFF -D BUILD_opencv_python2=OFF -D BUILD_opencv_python3=OFF -DWITH_1394=OFF -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON -DBUILD_JASPER=ON -DBUILD_JPEG=ON -DBUILD_PNG=ON -DBUILD_OPENCL=OFF -DOPENCV_DNN_OPENCL=OFF -DWITH_PNG=ON -DWITH_MKL=OFF -DMKL_WITH_TBB=OFF -DMKL_USE_MULTITHREAD=OFF -DMKL_WITH_OPENMP=OFF -DWITH_ITT=OFF -DWITH_FFMPEG=OFF -DWITH_GSTREAMER=OFF -DWITH_DSHOW=OFF -DWITH_MSMF=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_IPP_IW=OFF -DBUILD_ITT=OFF -DBUILD_opencv_apps=OFF -DBUILD_opencv_calib3d=OFF -DBUILD_opencv_dnn=OFF -DBUILD_opencv_features2d=OFF -DBUILD_opencv_flann=OFF -DBUILD_opencv_gapi=OFF -DBUILD_opencv_highgui=OFF -DBUILD_opencv_imgcodecs=ON -DBUILD_opencv_imgproc=ON -DBUILD_opencv_java=ON -DBUILD_opencv_java_bindings_generator=ON -DBUILD_opencv_js=OFF -DBUILD_opencv_ml=OFF -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_python2=OFF -DBUILD_opencv_python3=OFF -DBUILD_opencv_python_bindings_generator=OFF -DBUILD_opencv_python_tests=OFF -DBUILD_opencv_stitching=OFF -DBUILD_opencv_video=OFF -DBUILD_opencv_videoio=OFF -DBUILD_PROTOBUF=OFF -DWITH_IPP=OFF -DWITH_GTK=OFF -DWITH_OPENEXR=OFF -DWITH_JASPER=OFF -DWITH_WEBP=OFF -DWITH_OPENCL=OFF -DWITH_V4L=OFF -DWITH_VTK=OFF ..
`