### PR TITLE
[PPML] Add TDX device check for loader of libtdx-attest

### DIFF
--- a/ppml/src/main/java/com/intel/analytics/bigdl/ppml/dcap/Loader.java
+++ b/ppml/src/main/java/com/intel/analytics/bigdl/ppml/dcap/Loader.java
@@ -36,8 +36,14 @@ public class Loader {
     private String os = System.getProperty("os.name").toLowerCase();
 
     public void init() throws IOException {
-        libraries.add("quote_verification");
-        libraries.add("tdx_quote_generation");
+        File sgx_dev = new File("/dev/sgx/enclave");
+        if (sgx_dev.exists()) {
+            libraries.add("quote_verification");
+        }
+        File tdx_dev = new File("/dev/tdx-attest");
+        if (tdx_dev.exists()) {
+            libraries.add("tdx_quote_generation");
+        }
 
         Path tempDir = null;
         if (os.contains("win")) {
@@ -48,9 +54,12 @@ public class Loader {
 
         copyAll(tempDir);
 
-        loadLibrary("quote_verification", tempDir);
-        loadLibrary("tdx_quote_generation", tempDir);
-
+        if (sgx_dev.exists()) {
+            loadLibrary("quote_verification", tempDir);
+        }
+        if (tdx_dev.exists()) {
+            loadLibrary("tdx_quote_generation", tempDir);
+        }
         deleteAll(tempDir);
     }
 

--- a/ppml/src/main/java/com/intel/analytics/bigdl/ppml/dcap/Loader.java
+++ b/ppml/src/main/java/com/intel/analytics/bigdl/ppml/dcap/Loader.java
@@ -36,13 +36,14 @@ public class Loader {
     private String os = System.getProperty("os.name").toLowerCase();
 
     public void init() throws IOException {
-        File sgx_dev = new File("/dev/sgx/enclave");
-        if (sgx_dev.exists()) {
-            libraries.add("quote_verification");
-        }
+        // TODO: check SGX device to determine whether to load libquote_verification
+        libraries.add("quote_verification");
+
         File tdx_dev = new File("/dev/tdx-attest");
         if (tdx_dev.exists()) {
             libraries.add("tdx_quote_generation");
+        } else {
+            System.out.println("Not found /dev/tdx-attest, disable TDX quote generation.");
         }
 
         Path tempDir = null;
@@ -54,9 +55,8 @@ public class Loader {
 
         copyAll(tempDir);
 
-        if (sgx_dev.exists()) {
-            loadLibrary("quote_verification", tempDir);
-        }
+        loadLibrary("quote_verification", tempDir);
+        
         if (tdx_dev.exists()) {
             loadLibrary("tdx_quote_generation", tempDir);
         }


### PR DESCRIPTION
Currently using bigdl-core-ppml (com.intel.analytics.bigdl.ppml.dcap.Attestation) would get failed bacause of `libtdx_attest.so.1: cannot open shared object file: No such file or directory`. But it's not necessary to install `libtdx_attest` if don't need to generate TDX quote.