### PR TITLE
[PPML] Add OS requirement to bigdl-core-ppml README

### DIFF
--- a/ppml/README.md
+++ b/ppml/README.md
@@ -2,6 +2,10 @@
 
 C++ SGX/TDX attestation module for PPML
 
+## Supported operating systems
+
+* Ubuntu 20.04 LTS Server 64bits
+
 ## Requirements
  
 1. [Install Intel SGX SDK](https://github.com/intel/linux-sgx#install-the-intelr-sgx-sdk)


### PR DESCRIPTION
`libtdx-attest` is not provided officially in Ubuntu 18.04, so need to use Ubuntu 20.04 to build bigdl-core-ppml.